### PR TITLE
JSON storage of studies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea
 .DS_Store
 Booked_Hours_PaddyLamont.xls
+package-lock.json
 
 # dependencies
 /node_modules

--- a/src/components/StudyUpload.js
+++ b/src/components/StudyUpload.js
@@ -48,20 +48,20 @@ export class StudyUploadForm extends Component {
             .load(buffer)
             .then((workbook) => {
                 updateStatusFn(Status.progress("Reading spreadsheet..."));
-                let study = null;
-                try {
-                    study = readStudyWorkbook(workbook);
-                } catch (error) {
-                    updateStatusFn(Status.error([
-                        <strong>Error reading spreadsheet:</strong>,
-                        error.message
-                    ]));
-                    return;
-                }
-                updateStatusFn(Status.success("Success"));
-                if (this.props.onStudyLoad) {
-                    this.props.onStudyLoad(study);
-                }
+                readStudyWorkbook(workbook)
+                    .then((study) => {
+                        updateStatusFn(Status.success("Success"));
+                        if (this.props.onStudyLoad) {
+                            this.props.onStudyLoad(study);
+                        }
+                    })
+                    .catch((error) => {
+                        console.error(error);
+                        updateStatusFn(Status.error([
+                            <strong>Error reading spreadsheet:</strong>,
+                            error.message
+                        ]));
+                    });
             })
             .catch((error) => {
                 updateStatusFn(Status.error([

--- a/src/model/images.js
+++ b/src/model/images.js
@@ -1,0 +1,129 @@
+import {doTypeCheck} from "../utils/types";
+import {base64ToBytes, bytesToBase64} from "../utils/base64";
+
+
+/**
+ * We limit the size of images to 500 KiB to stay
+ * within the Firestore 1 MiB object limit after
+ * conversion to base 64.
+ */
+export const FIRESTORE_IMAGE_LIMIT = {
+    bytes: 500 * 1024,
+    text: "500 KiB"
+};
+
+/**
+ * Creates a canvas element to draw into.
+ * Taken from https://github.com/Sothatsit/RoyalUrClient.
+ */
+function renderResource(width, height, renderFunction) {
+    if (isNaN(width) || isNaN(height))
+        throw new Error("Width and height cannot be NaN, was given " + width + " x " + height);
+    if (width < 1 || height < 1)
+        throw new Error("Width and height must both be at least 1, was given " + width + " x " + height);
+
+    const canvas = document.createElement("canvas"),
+          ctx = canvas.getContext("2d");
+
+    canvas.width = width;
+    canvas.height = height;
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = "high";
+    renderFunction(ctx, canvas);
+    return canvas;
+}
+
+/**
+ * Halves the dimension of {@param image} by drawing a
+ * scaled down version of it into a Canvas element.
+ */
+function halveImageSize(image) {
+    const scaledWidth = Math.round(image.width / 2);
+    const scaledHeight = Math.round(image.height / 2);
+    return renderResource(scaledWidth, scaledHeight, (ctx) => {
+        ctx.drawImage(image, 0, 0, scaledWidth, scaledHeight);
+    });
+}
+
+/**
+ * Represents an image such as a post or an avatar.
+ */
+export class StudyImage {
+    buffer; // Uint8Array
+    type; // String
+
+    constructor(buffer, type) {
+        doTypeCheck(buffer, Uint8Array);
+        doTypeCheck(type, "string");
+        this.buffer = buffer;
+        this.type = type;
+    }
+
+    getBytes() {
+        return this.buffer.length;
+    }
+
+    /**
+     * This will scale down this image until it fits within the
+     * Firestore image limit defined in FIRESTORE_IMAGE_LIMIT.
+     */
+    async scaleDown() {
+        return new Promise((resolve, reject) => {
+            // If this image is within the limit, fulfill the callback.
+            if (this.getBytes() < FIRESTORE_IMAGE_LIMIT.bytes) {
+                resolve(this);
+                return;
+            }
+
+            // Otherwise halve the size of the image and try again.
+            try {
+                this.createImage().then((image) => {
+                    const scaled = halveImageSize(image);
+                    scaled.toBlob((blob) => {
+                        blob.arrayBuffer().then((arrayBuffer) => {
+                            try {
+                                const newBuffer = new Uint8Array(arrayBuffer);
+                                const newImage = new StudyImage(newBuffer, blob.type);
+                                newImage.scaleDown().then(resolve, reject);
+                            } catch (error) {
+                                reject(error);
+                            }
+                        }).catch(reject);
+                    }, this.type, 0.9);
+                }).catch(reject);
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    createImage() {
+        return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.src = URL.createObjectURL(
+                new Blob([this.buffer.buffer], { type: this.type })
+            );
+            image.onload = () => resolve(image);
+            image.onerror = () => reject(new Error("Image could not be created from Blob"));
+            return image;
+        });
+    }
+
+    toJSON() {
+        return {
+            "type": this.type,
+            "buffer": bytesToBase64(this.buffer)
+        };
+    }
+
+    /**
+     * Returns a Promise to a StudyImage from the given excel image.
+     */
+    static fromExcelImage(excelImage) {
+        return new StudyImage(excelImage.buffer, "image/" + excelImage.extension).scaleDown();
+    }
+
+    static fromJSON(json) {
+        return new StudyImage(json["type"], base64ToBytes(json["buffer"]))
+    }
+}

--- a/src/model/math.js
+++ b/src/model/math.js
@@ -1,5 +1,5 @@
 import {doTypeCheck} from "../utils/types";
-import {randNormal} from "../utils/normalDistribution";
+import {randNormal} from "../utils/random";
 
 
 /**
@@ -19,6 +19,19 @@ export class LinearFunction {
 
     get(x) {
         return x * this.slope + this.intercept;
+    }
+
+    toJSON() {
+        return {
+            "slope": this.slope,
+            "intercept": this.intercept
+        };
+    }
+
+    static fromJSON(json) {
+        return new LinearFunction(
+            json["slope"], json["intercept"]
+        );
     }
 }
 
@@ -49,10 +62,29 @@ export class TruncatedNormalDistribution {
      * Randomly samples this distribution.
      */
     sample() {
+        if (this.stdDeviation <= 0)
+            return this.mean;
+
         let value;
         do {
             value = this.mean + randNormal() * this.stdDeviation;
         } while (value < this.min || value > this.max);
         return value;
+    }
+
+    toJSON() {
+        return {
+            "mean": this.mean,
+            "stdDeviation": this.stdDeviation,
+            "min": this.min,
+            "max": this.max
+        };
+    }
+
+    static fromJSON(json) {
+        return new TruncatedNormalDistribution(
+            json["mean"], json["stdDeviation"],
+            json["min"], json["max"]
+        );
     }
 }

--- a/src/model/selectionMethod.js
+++ b/src/model/selectionMethod.js
@@ -6,11 +6,30 @@ import {LinearFunction} from "./math";
  * Represents a method of selecting source and post pairs.
  */
 export class SourcePostSelectionMethod {
-    name; // String
+    type; // String
 
-    constructor(name) {
-        doTypeCheck(name, "string");
-        this.name = name;
+    constructor(type) {
+        doTypeCheck(type, "string");
+        this.type = type;
+    }
+
+    toJSON() {
+        return {
+            "type": this.type
+        };
+    }
+
+    static fromJSON(json) {
+        const type = json["type"];
+        if (type === "Overall-Ratio")
+            return OverallRatioSelectionMethod.fromJSON(json);
+        if (type === "Source-Ratios")
+            return SourceRatioSelectionMethod.fromJSON(json);
+        if (type === "Credibility")
+            return CredibilitySelectionMethod.fromJSON(json);
+        if (type === "Pre-Defined")
+            return PredefinedSelectionMethod.fromJSON(json);
+        throw new Error("Unknown SourcePostSelectionMethod type: " + type);
     }
 }
 
@@ -27,6 +46,19 @@ export class OverallRatioSelectionMethod extends SourcePostSelectionMethod {
         doTypeCheck(truePostPercentage, "number");
         this.truePostPercentage = truePostPercentage;
     }
+
+    toJSON() {
+        return {
+            ...super.toJSON(),
+            "truePostPercentage": this.truePostPercentage
+        };
+    }
+
+    static fromJSON(json) {
+        return new OverallRatioSelectionMethod(
+            json["truePostPercentage"]
+        );
+    }
 }
 
 /**
@@ -37,6 +69,14 @@ export class OverallRatioSelectionMethod extends SourcePostSelectionMethod {
 export class SourceRatioSelectionMethod extends SourcePostSelectionMethod {
     constructor() {
         super("Source-Ratios");
+    }
+
+    toJSON() {
+        return super.toJSON();
+    }
+
+    static fromJSON(json) {
+        return new SourceRatioSelectionMethod();
     }
 }
 
@@ -53,6 +93,19 @@ export class CredibilitySelectionMethod extends SourcePostSelectionMethod {
         doTypeCheck(linearRelationship, LinearFunction);
         this.linearRelationship = linearRelationship;
     }
+
+    toJSON() {
+        return {
+            ...super.toJSON(),
+            "linearRelationship": this.linearRelationship.toJSON()
+        };
+    }
+
+    static fromJSON(json) {
+        return new CredibilitySelectionMethod(
+            LinearFunction.fromJSON(json["linearRelationship"])
+        );
+    }
 }
 
 /**
@@ -66,5 +119,18 @@ export class PredefinedSelectionMethod extends SourcePostSelectionMethod {
         super("Pre-Defined");
         doTypeCheck(order, Array);
         this.order = order;
+    }
+
+    toJSON() {
+        return {
+            ...super.toJSON(),
+            "order": this.order
+        };
+    }
+
+    static fromJSON(json) {
+        return new PredefinedSelectionMethod(
+            json["order"]
+        );
     }
 }

--- a/src/model/study.js
+++ b/src/model/study.js
@@ -29,24 +29,31 @@ export class StudyImage {
     static fromExcelImage(excelImage) {
         return new StudyImage(excelImage.buffer, "image/" + excelImage.extension);
     }
+
+    toJSON() {
+        throw new Error(
+            "I don't know the best way to store this in JSON... base64 maybe? " +
+            "Although, that said, storing them in Firebase Storage may be the " +
+            "the best solution (it would just be more complicated...)"
+        );
+    }
 }
 
 /**
- * A source that can be used for posts or comments.
+ * A source that is missing some information, but at least
+ * contains enough info to perform the source/post selection.
  */
-export class Source {
+export class BaseSource {
     id; // String
     name; // String
-    avatar; // Avatar
     maxPosts; // Number
     followers; // TruncatedNormalDistribution
     credibility; // TruncatedNormalDistribution
     truePostPercentage; // null or Number
 
-    constructor(id, name, avatar, maxPosts, followers, credibility, truePostPercentage) {
+    constructor(id, name, maxPosts, followers, credibility, truePostPercentage) {
         doTypeCheck(id, "string");
         doTypeCheck(name, "string");
-        doTypeCheck(avatar, StudyImage);
         doTypeCheck(maxPosts, "number");
         doTypeCheck(followers, TruncatedNormalDistribution);
         doTypeCheck(credibility, TruncatedNormalDistribution);
@@ -56,11 +63,60 @@ export class Source {
 
         this.id = id;
         this.name = name;
-        this.avatar = avatar;
         this.maxPosts = maxPosts;
         this.followers = followers;
         this.credibility = credibility;
         this.truePostPercentage = truePostPercentage;
+    }
+
+    toBaseSource() {
+        return this;
+    }
+
+    isFullSource() {
+        return false;
+    }
+
+    toJSON() {
+        return {
+            "id": this.id,
+            "name": this.name,
+            "followers": this.followers.toJSON(),
+            "credibility": this.credibility.toJSON(),
+            "truePostPercentage": this.truePostPercentage
+        };
+    }
+}
+
+/**
+ * A source that can be used for posts or comments.
+ */
+export class Source extends BaseSource {
+    avatar; // Avatar
+
+    constructor(id, name, avatar, maxPosts, followers, credibility, truePostPercentage) {
+        super(id, name, maxPosts, followers, credibility, truePostPercentage);
+        doTypeCheck(avatar, StudyImage);
+        this.avatar = avatar;
+    }
+
+    toBaseSource() {
+        return new BaseSource(
+            this.id, this.name, this.maxPosts,
+            this.followers, this.credibility,
+            this.truePostPercentage
+        );
+    }
+
+    isFullSource() {
+        return true;
+    }
+
+    toJSON() {
+        return {
+            ...super.toJSON(),
+            "avatar": this.avatar.toJSON()
+        };
     }
 }
 
@@ -80,6 +136,14 @@ export class PostComment {
         this.sourceID = sourceID;
         this.message = message;
         this.likes = likes;
+    }
+
+    toJSON() {
+        return {
+            "sourceID": this.sourceID,
+            "message": this.message,
+            "likes": this.likes
+        };
     }
 }
 
@@ -103,35 +167,93 @@ export class ReactionValues {
         this.share = share;
         this.flag = flag;
     }
+
+    toJSON() {
+        return {
+            "like": this.like,
+            "dislike": this.dislike,
+            "share": this.share,
+            "flag": this.flag
+        };
+    }
 }
 
 /**
- * Holds the contents of a post.
+ * A post that is missing some information, but at least
+ * contains enough info to perform the source/post selection.
  */
-export class Post {
+export class BasePost {
     id; // String -> [DL] Consider switching to number type
     headline; // String
-    content; // StudyImage or String
     isTrue; // Boolean
     changesToFollowers; // ReactionValues
     changesToCredibility; // ReactionValues
     comments; // PostComment[]
 
-    constructor(id, headline, content, isTrue, changesToFollowers, changesToCredibility, comments) {
+    constructor(id, headline, isTrue, changesToFollowers, changesToCredibility, comments) {
         doTypeCheck(id, "number");
         doTypeCheck(headline, "string");
-        doTypeCheck(content, [StudyImage, "string"]);
         doTypeCheck(isTrue, "boolean");
         doTypeCheck(changesToFollowers, ReactionValues);
         doTypeCheck(changesToCredibility, ReactionValues);
         doTypeCheck(comments, Array);
-
         this.id = id;
         this.headline = headline;
-        this.content = content;
         this.isTrue = isTrue;
         this.changesToFollowers = changesToFollowers;
         this.changesToCredibility = changesToCredibility;
+        this.comments = comments;
+    }
+
+    toBasePost() {
+        return this;
+    }
+
+    isFullPost() {
+        return false;
+    }
+
+    toJSON() {
+        const commentsJSON = [];
+        for (let index = 0; index < this.comments.length; ++index) {
+            commentsJSON.push(this.comments[index].toJSON())
+        }
+        return {
+            "id": this.id,
+            "headline": this.headline,
+            "isTrue": this.isTrue,
+            "changesToFollowers": this.changesToFollowers.toJSON(),
+            "changesToCredibility": this.changesToCredibility.toJSON(),
+            "comments": commentsJSON
+        };
+    }
+}
+
+/**
+ * Holds the contents of a post.
+ */
+export class Post extends BasePost {
+    content; // StudyImage or String
+
+    constructor(id, headline, content, isTrue, changesToFollowers, changesToCredibility, comments) {
+        super(id, headline, isTrue, changesToFollowers, changesToCredibility, comments);
+        doTypeCheck(content, [StudyImage, "string"]);
+        this.content = content;
+    }
+
+    toBasePost() {
+        return new BasePost(this.id, this.headline, this.isTrue);
+    }
+
+    isFullPost() {
+        return true;
+    }
+
+    toJSON() {
+        return {
+            ...super.toJSON(),
+            "content": this.content.toJSON()
+        };
     }
 }
 
@@ -180,5 +302,61 @@ export class Study {
         this.sourcePostSelectionMethod = sourcePostSelectionMethod;
         this.sources = sources;
         this.posts = posts;
+    }
+
+    /**
+     * Returns all the stripped-down sources for
+     * use in source/post selection.
+     * This list will always be available.
+     */
+    getBaseSources() {
+        const base = [];
+        for (let index = 0; index < this.sources.length; ++index) {
+            base.push(this.sources[index].toBaseSource());
+        }
+        return base;
+    }
+
+    /**
+     * Returns all the stripped-down posts
+     * for use in source/post selection.
+     * This list will always be available.
+     */
+    getBasePosts() {
+        const base = [];
+        for (let index = 0; index < this.posts.length; ++index) {
+            base.push(this.posts[index].toBasePost());
+        }
+        return base;
+    }
+
+    /**
+     * This does _not_ include the full source and post
+     * information, just the base information.
+     */
+    toJSON() {
+        const sources = this.getBaseSources();
+        const sourceJSONs = [];
+        for (let index = 0; index < sources.length; ++index) {
+            sourceJSONs.push(sources[index].toJSON());
+        }
+        const posts = this.getBasePosts();
+        const postJSONs = [];
+        for (let index = 0; index < posts.length; ++index) {
+            postJSONs.push(posts[index].toJSON());
+        }
+        return {
+            "name": this.name,
+            "description": this.description,
+            "introduction": this.introduction,
+            "prompt": this.prompt,
+            "length": this.length,
+            "debrief": this.debrief,
+            "genCompletionCode": this.genCompletionCode,
+            "maxCompletionCode": this.maxCompletionCode,
+            "sourcePostSelectionMethod": this.sourcePostSelectionMethod.toJSON(),
+            "sources": sourceJSONs,
+            "posts": postJSONs
+        }
     }
 }

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -1,0 +1,124 @@
+/*
+MIT License
+Copyright (c) 2020 Egor Nepomnyaschih
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+// This constant can also be computed with the following algorithm:
+const base64abc = [],
+	A = "A".charCodeAt(0),
+	a = "a".charCodeAt(0),
+	n = "0".charCodeAt(0);
+for (let i = 0; i < 26; ++i) {
+	base64abc.push(String.fromCharCode(A + i));
+}
+for (let i = 0; i < 26; ++i) {
+	base64abc.push(String.fromCharCode(a + i));
+}
+for (let i = 0; i < 10; ++i) {
+	base64abc.push(String.fromCharCode(n + i));
+}
+base64abc.push("+");
+base64abc.push("/");
+*/
+const base64abc = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+    "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+    "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "+", "/"
+];
+
+/*
+// This constant can also be computed with the following algorithm:
+const l = 256, base64codes = new Uint8Array(l);
+for (let i = 0; i < l; ++i) {
+	base64codes[i] = 255; // invalid character
+}
+base64abc.forEach((char, index) => {
+	base64codes[char.charCodeAt(0)] = index;
+});
+base64codes["=".charCodeAt(0)] = 0; // ignored anyway, so we just need to prevent an error
+*/
+const base64codes = [
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62, 255, 255, 255, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 255, 255, 255, 0, 255, 255,
+    255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255,
+    255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+];
+
+function getBase64Code(charCode) {
+    if (charCode >= base64codes.length) {
+        throw new Error("Unable to parse base64 string.");
+    }
+    const code = base64codes[charCode];
+    if (code === 255) {
+        throw new Error("Unable to parse base64 string.");
+    }
+    return code;
+}
+
+export function bytesToBase64(bytes) {
+    let result = '', i, l = bytes.length;
+    for (i = 2; i < l; i += 3) {
+        result += base64abc[bytes[i - 2] >> 2];
+        result += base64abc[((bytes[i - 2] & 0x03) << 4) | (bytes[i - 1] >> 4)];
+        result += base64abc[((bytes[i - 1] & 0x0F) << 2) | (bytes[i] >> 6)];
+        result += base64abc[bytes[i] & 0x3F];
+    }
+    if (i === l + 1) { // 1 octet yet to write
+        result += base64abc[bytes[i - 2] >> 2];
+        result += base64abc[(bytes[i - 2] & 0x03) << 4];
+        result += "==";
+    }
+    if (i === l) { // 2 octets yet to write
+        result += base64abc[bytes[i - 2] >> 2];
+        result += base64abc[((bytes[i - 2] & 0x03) << 4) | (bytes[i - 1] >> 4)];
+        result += base64abc[(bytes[i - 1] & 0x0F) << 2];
+        result += "=";
+    }
+    return result;
+}
+
+export function base64ToBytes(str) {
+    if (str.length % 4 !== 0) {
+        throw new Error("Unable to parse base64 string.");
+    }
+    const index = str.indexOf("=");
+    if (index !== -1 && index < str.length - 2) {
+        throw new Error("Unable to parse base64 string.");
+    }
+    let missingOctets = str.endsWith("==") ? 2 : str.endsWith("=") ? 1 : 0,
+        n = str.length,
+        result = new Uint8Array(3 * (n / 4)),
+        buffer;
+    for (let i = 0, j = 0; i < n; i += 4, j += 3) {
+        buffer = (getBase64Code(str.charCodeAt(i)) << 18) |
+                 (getBase64Code(str.charCodeAt(i + 1)) << 12) |
+                 (getBase64Code(str.charCodeAt(i + 2)) << 6) |
+                 getBase64Code(str.charCodeAt(i + 3));
+        result[j] = buffer >> 16;
+        result[j + 1] = (buffer >> 8) & 0xFF;
+        result[j + 2] = buffer & 0xFF;
+    }
+    return result.subarray(0, result.length - missingOctets);
+}

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -252,3 +252,16 @@ export function readCell(workbook, loc) {
     }
     return value;
 }
+
+/**
+ * Reads the value of the cell at the given location {@param loc}
+ * in {@param workbook}. If the cell is blank, this will return
+ * {@param defaultValue} instead. If the value is not of the
+ * expected type, then an error will be thrown.
+ */
+export function readCellWithDefault(workbook, loc, defaultValue) {
+    if (isCellBlank(workbook, loc))
+        return defaultValue;
+
+    return readCell(workbook, loc);
+}

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -24,3 +24,22 @@ export function randNormal() {
     const v = randUniform01Exclusive();
     return Math.sqrt( -2.0 * Math.log( u ) ) * Math.cos( 2.0 * Math.PI * v );
 }
+
+/**
+ * Generates a string containing {@param digits} integer
+ * digits to generate an N-digit integer. The first digit
+ * will be a random number from 1-9, and the remaining
+ * digits will be random digits from 0-9.
+ */
+export function randDigits(digits) {
+    if (digits < 1)
+        throw new Error("Digits must be positive, not " + digits);
+
+    // First digit can be from 1-9.
+    let num = "" + Math.floor((Math.random()*9)+1);
+    // The remaining digits can be from 0-9.
+    for (let digit = 2; digit <= digits; ++digit) {
+        num += Math.floor((Math.random()*10));
+    }
+    return num;
+}


### PR DESCRIPTION
This PR adds the following:
1. Finishes the conversion of `Study` objects to JSON. (`Study#toJSON()`, `Post#toJSON()`, and `Source#toJSON()`)
2. Adds the conversion from JSON back to a `Study` object.
3. Automatically down-scales images if they are larger than 500 KiB to ensure they can fit in Firestore.
4. Updates to allow reading new changes to the study spreadsheet (e.g. default values).